### PR TITLE
added add operation on tai for durations < 1 sec

### DIFF
--- a/tai.go
+++ b/tai.go
@@ -354,17 +354,17 @@ func (t TAI) Add(sec, asec int64) TAI {
 // in the Add method. This is a limitation of the int64 type
 // The Following methods can add up to 2^63 Millseconds, MicroSeconds and Nanoseconds respectively
 
-// AddMs returns t with added Milliseconds
+// AddMilliseconds returns t with added Milliseconds
 func (t TAI) AddMilliseconds(msec int64) TAI {
 	return t.Add(msec/1e3, (msec%1e3)*Millisecond)
 }
 
-// AddMus returns t with added Nanoseconds
+// AddMicroseconds returns t with added Microseconds
 func (t TAI) AddMicroseconds(musec int64) TAI {
 	return t.Add(musec/1e6, (musec%1e6)*Microsecond)
 }
 
-// AddNs returns t with added Nanoseconds
+// AddNanoseconds returns t with added Nanoseconds
 func (t TAI) AddNanoseconds(nsec int64) TAI {
 	return t.Add(nsec/1e9, (nsec%1e9)*Nanosecond)
 }

--- a/tai.go
+++ b/tai.go
@@ -119,7 +119,7 @@ func removeLeap(slc []leap, index int) []leap {
 // skew need not be 1 and need not be positive
 //
 // inserting a leap prior to the first leap second (Jan 1, 1970) will produce an
-//error, since there were no leap seconds prior to that time.
+// error, since there were no leap seconds prior to that time.
 //
 // RegisterLeapSecond is thread safe; any in-progress AsTime/FromTime conversions
 // will complete before the table is updated.
@@ -195,17 +195,17 @@ type TAI struct {
 }
 
 func Tai(sec, asec int64) TAI {
-	if asec > 1e18 {
-		spareSecs := asec / 1e18
-		asec %= 1e18
-		sec += spareSecs
-	}
-	// this is not the fastest possible way to fix negative asec, but
-	// this error correction will be rare
-	for asec < 0 {
+
+	spareSecs := asec / 1e18
+	asec %= 1e18
+	sec += spareSecs
+
+	//by definition 0 <= asec < 1e18
+	if asec < 0 {
 		asec += 1e18
-		sec--
+		sec -= Second
 	}
+
 	return TAI{sec: sec, asec: asec}
 }
 
@@ -333,6 +333,40 @@ func (t TAI) AddHMS(h, m, s int) TAI {
 	t.sec += int64(m * Minute)
 	t.sec += int64(s)
 	return t
+}
+
+// Add returns t offset by the given seconds and attoseconds
+func (t TAI) Add(sec, asec int64) TAI {
+
+	t.asec += asec
+	t.sec += t.asec/1e18 + sec
+	t.asec %= 1e18
+
+	if t.asec < 0 {
+		t.asec += 1e18
+		t.sec -= Second
+	}
+	return t
+}
+
+// The Following three methods are for convenience.
+// They also take care of the fact that you cannot add more than 9.223372e+18 (2^63) attoseconds
+// in the Add method. This is a limitation of the int64 type
+// The Following methods can add up to 2^63 Millseconds, MicroSeconds and Nanoseconds respectively
+
+// AddMs returns t with added Milliseconds
+func (t TAI) AddMilliseconds(msec int64) TAI {
+	return t.Add(msec/1e3, (msec%1e3)*Millisecond)
+}
+
+// AddMus returns t with added Nanoseconds
+func (t TAI) AddMicroseconds(musec int64) TAI {
+	return t.Add(musec/1e6, (musec%1e6)*Microsecond)
+}
+
+// AddNs returns t with added Nanoseconds
+func (t TAI) AddNanoseconds(nsec int64) TAI {
+	return t.Add(nsec/1e9, (nsec%1e9)*Nanosecond)
 }
 
 // AsTime returns t as a Time object

--- a/tai_test.go
+++ b/tai_test.go
@@ -185,6 +185,88 @@ func TestTaiBeforeAfterEq(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestTaiNegativeAsecs(t *testing.T) {
+	t1 := tai.Tai(10, 1e18)
+	t2 := tai.Tai(11, 0)
+	t3 := tai.Tai(12, -1e18)
+	t4 := tai.Tai(12, -1e18-10)
+	if !t1.Eq(t2) {
+		t.Fatalf("t1: %+v is not equal to t2: %+v", t1, t2)
+	}
+	if !t3.Eq(t2) {
+		t.Fatalf("t2: %+v is not equal to t3: %+v", t2, t3)
+	}
+	// remaining attoseconds should be positive and seconds decremented
+	if !t2.After(t4) {
+		t.Fatalf("t2: %+v is not after to t4: %+v", t2, t4)
+	}
+}
+
+func TestTaiAdd(t *testing.T) {
+	t1 := tai.Tai(10, 5)
+	t2 := tai.Tai(13, 6)
+	t3 := t1.Add(3, 1)
+	t4 := tai.Tai(12, -1e18-10)
+	t5 := t4.Add(0, 16+2*1e18)
+	t6 := tai.Tai(100, 1)
+	t7 := t6.Add(-78, -9*1e18).Add(0, -9*1e18).Add(0, 9*1e18+5)
+	if !t3.Eq(t2) {
+		t.Fatalf("t2: %+v not equal to t3: %+v", t2, t3)
+	}
+	if !t5.Eq(t2) {
+		t.Fatalf("t2: %+v not equal to t5: %+v", t2, t5)
+	}
+	if !t7.Eq(t2) {
+		t.Fatalf("t2: %+v not equal to t7: %+v", t2, t7)
+	}
+}
+
+func TestTaiAddMilliseconds(t *testing.T) {
+	t1 := tai.Tai(0, 0)
+	t2 := tai.Tai(9e15, 0)
+	t3 := t1.AddMilliseconds(9e18)
+	t4 := tai.Tai(100, 100)
+	t5 := t4.AddMilliseconds(-1e5)
+	t6 := tai.Tai(0, 100)
+	if !t3.Eq(t2) {
+		t.Fatalf("t2: %+v not equal to t3: %+v", t2, t3)
+	}
+	if !t5.Eq(t6) {
+		t.Fatalf("t6: %+v not equal to t5: %+v", t6, t5)
+	}
+}
+
+func TestTaiAddMicroseconds(t *testing.T) {
+	t1 := tai.Tai(0, 0)
+	t2 := tai.Tai(9e12, 0)
+	t3 := t1.AddMicroseconds(9e18)
+	t4 := tai.Tai(100, 100)
+	t5 := t4.AddMicroseconds(-1e8)
+	t6 := tai.Tai(0, 100)
+	if !t3.Eq(t2) {
+		t.Fatalf("t2: %+v not equal to t3: %+v", t2, t3)
+	}
+	if !t5.Eq(t6) {
+		t.Fatalf("t6: %+v not equal to t5: %+v", t6, t5)
+	}
+}
+
+func TestTaiAddNanoseconds(t *testing.T) {
+	t1 := tai.Tai(0, 0)
+	t2 := tai.Tai(9e9, 0)
+	t3 := t1.AddNanoseconds(9e18)
+	t4 := tai.Tai(100, 100)
+	t5 := t4.AddNanoseconds(-1e11)
+	t6 := tai.Tai(0, 100)
+	if !t3.Eq(t2) {
+		t.Fatalf("t2: %+v not equal to t3: %+v", t2, t3)
+	}
+	if !t5.Eq(t6) {
+		t.Fatalf("t6: %+v not equal to t5: %+v", t6, t5)
+	}
+}
+
 func TestUnixEpoch(t *testing.T) {
 	ta := tai.Tai(4383*tai.Day, 0)
 	date := ta.AsGregorian()


### PR DESCRIPTION
Some use cases might require the addition of durations that are less than 1 second.
There was no way to to this up to now, I have added 4 methods to do that.

